### PR TITLE
Change routes for internal api

### DIFF
--- a/app/assets/javascripts/ideas.js
+++ b/app/assets/javascripts/ideas.js
@@ -21,7 +21,7 @@ function createIdea(){
   var ideaParams = {idea: {title: $('#idea-title').val(),
                            body: $('#idea-body').val()}}
   $.ajax({
-    url: "/ideas",
+    url: "/api/v1/ideas",
     method: "POST",
     dataType: "json",
     data: ideaParams,

--- a/app/controllers/api/v1/ideas_controller.rb
+++ b/app/controllers/api/v1/ideas_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::IdeasController < ApplicationController
+  respond_to :json
+
+  def create
+    idea = Idea.new(idea_params)
+    if idea.save
+      respond_with idea, location: nil
+    end
+  end
+
+  private
+
+    def idea_params
+      params.require(:idea).permit(:title, :body)
+    end
+end

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -1,20 +1,6 @@
 class IdeasController < ApplicationController
-  respond_to :json, :html
 
   def index
     @ideas = Idea.all
   end
-
-  def create
-    @idea = Idea.new(idea_params)
-    if @idea.save
-      respond_with @idea
-    end
-  end
-
-  private
-
-    def idea_params
-      params.require(:idea).permit(:title, :body)
-    end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,10 @@
 Rails.application.routes.draw do
   root          to: "ideas#index"
   get "/ideas", to: "ideas#index"
-  resources :ideas, except: :index, defaults: {format: :json}
+
+  namespace :api do
+    namespace :v1 do
+      resources :ideas, only: [:index, :create]
+    end
+  end
 end

--- a/spec/controllers/api/v1/ideas_controller_spec.rb
+++ b/spec/controllers/api/v1/ideas_controller_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+RSpec.describe IdeasController, type: :controller do
+  describe "GET #index" do
+    it "returns ideas" do
+      idea = create_list(:idea, 2)
+
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
Previously I used the same ideas controller for all routes, api or otherwise. I created a unique api/v1 controller for handling creating creating new ideas, and will use for all other verb actions.

closes #15 
