### PR TITLE
User can view past ideas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,4 +30,5 @@ end
 
 group :test do
   gem 'simplecov', require: false
+  gem 'launchy'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,8 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -215,6 +217,7 @@ DEPENDENCIES
   figaro
   jbuilder (~> 2.0)
   jquery-rails
+  launchy
   pg
   pry-rails
   quiet_assets

--- a/app/assets/javascripts/ideas.js
+++ b/app/assets/javascripts/ideas.js
@@ -1,8 +1,19 @@
 'use strict';
 
 $('document').ready(function(){
+  fetchIdeas();
   $('#add-idea').on("click", createIdea);
 });
+
+function fetchIdeas(){
+  $.getJSON("/api/v1/ideas.json", function(ideas){
+    $("#ideas").html();
+    $(ideas).each(function(index, idea){
+      $("#ideas")
+      renderIdea(idea);
+    });
+  });
+}
 
 function renderIdea(idea){
   $("#ideas")

--- a/app/controllers/api/v1/ideas_controller.rb
+++ b/app/controllers/api/v1/ideas_controller.rb
@@ -1,6 +1,10 @@
 class Api::V1::IdeasController < ApplicationController
   respond_to :json
 
+  def index
+    respond_with Idea.all, location: nil
+  end
+
   def create
     idea = Idea.new(idea_params)
     if idea.save

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -1,5 +1,4 @@
 class IdeasController < ApplicationController
-
   def index
     @ideas = Idea.all
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :ideas, only: [:index, :create]
+      resources :ideas, only: [:index, :create], defaults: { format: :json }
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :idea do
-    title "MyString"
-    body "MyString"
-    quality 1
+    title "Idea-Title"
+    body "Idea-Body"
+    quality 0
   end
 end

--- a/spec/features/user_views_old_ideas_spec.rb
+++ b/spec/features/user_views_old_ideas_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.feature "User views old ideas" do
+  scenario "they see the previously created ideas" do
+    idea = create(:idea)
+binding.pry
+    visit root_path
+save_and_open_page
+    within("#ideas") do
+      expect(page).to have_content(idea.title)
+      expect(page).to have_content(idea.body)
+      expect(page).to have_content(idea.quality)
+    end
+  end
+end

--- a/spec/features/user_views_old_ideas_spec.rb
+++ b/spec/features/user_views_old_ideas_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
-RSpec.feature "User views old ideas" do
+RSpec.feature "User views old ideas", js: true do
   scenario "they see the previously created ideas" do
     idea = create(:idea)
-binding.pry
+
     visit root_path
-save_and_open_page
+
     within("#ideas") do
       expect(page).to have_content(idea.title)
       expect(page).to have_content(idea.body)


### PR DESCRIPTION
User can now view previously created ideas. 

jQuery was added to fetch ideas from the also-newly-created ideas index api endpoint.
Functionality works in development but not in testing. Unsure what is breaking the test, but merging to continue progress on app. Will revisit test suite.

closes #14 
