### PR TITLE
Remove /ideas route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
   root          to: "ideas#index"
-  get "/ideas", to: "ideas#index"
 
   namespace :api do
     namespace :v1 do


### PR DESCRIPTION
Removed path to /ideas. Root path is now the only non-api route.

closes #31 
