### PR TITLE
Idea body is truncated to 100 or less characters

### DIFF
--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -2,7 +2,10 @@ class Idea < ActiveRecord::Base
   enum quality: [:Swill, :Plausible, :Genius]
 
   validates :quality, inclusion: { in: qualities.keys }
-  #validation for  empty title and body
+  validates_presence_of :title
+  validates_presence_of :body
+
+  before_save :check_length
 
   def upvote
     self[:quality] += 1
@@ -10,5 +13,18 @@ class Idea < ActiveRecord::Base
 
   def downvote
     self[:quality] -= 1
+  end
+
+  def check_length
+    if self.body.length > 100
+      truncate(self.body)
+    end
+  end
+
+  def truncate(body)
+    if self.body.chars.last != " "
+      self.body = self.body[0..-2]
+      truncate(self.body)
+    end
   end
 end


### PR DESCRIPTION
Before save, if a body length is longer than 100 characters then it is cut off to the closest previous space.

-used callback in ideal to check and trim body length.

closes #21 
